### PR TITLE
Feature/fix example copy

### DIFF
--- a/src/main/java/io/noves/profiles/util/FshToDemisConversion.java
+++ b/src/main/java/io/noves/profiles/util/FshToDemisConversion.java
@@ -65,6 +65,11 @@ public class FshToDemisConversion {
         log.info("Copy example files");
         copyResources(targetDirectory.resolve("ExampleResources"), e -> e.getFileName().toString().endsWith("Example.json"), resourceDir);
 
+        // Copy package.json.template file
+        var templateDir = pathFshProject.resolve("package.json.template");
+        validateExistence(templateDir, "Expecting a file with name package.json.template to exist in the root of the fsh-directory.");
+        copyResources(targetDirectory, e-> true, templateDir);
+
         log.info("Finished copying resources!");
     }
 

--- a/src/main/java/io/noves/profiles/util/FshToDemisConversion.java
+++ b/src/main/java/io/noves/profiles/util/FshToDemisConversion.java
@@ -47,12 +47,12 @@ public class FshToDemisConversion {
 
         // Copy non StructureDefinition resources
         log.info("Copy terminology resources");
-        copyResources(meta.resolve("CodeSystem"), e -> e.getFileName().toString().startsWith("ValueSet"), resourceDir);
-        copyResources(meta.resolve("ValueSet"), e -> e.getFileName().toString().startsWith("CodeSystem"), resourceDir);
-        copyResources(meta.resolve("NamingSystem"), e -> e.getFileName().toString().startsWith("NamingSystem"), resourceDir);
+        copyResources(meta.resolve("CodeSystem"), e -> e.getFileName().toString().startsWith("ValueSet-"), resourceDir);
+        copyResources(meta.resolve("ValueSet"), e -> e.getFileName().toString().startsWith("CodeSystem-"), resourceDir);
+        copyResources(meta.resolve("NamingSystem"), e -> e.getFileName().toString().startsWith("NamingSystem-"), resourceDir);
 
         log.info("Copy Questionnaires");
-        copyResources(meta.resolve("Questionnaire"), e -> e.getFileName().toString().startsWith("Questionnaire"), resourceDir);
+        copyResources(meta.resolve("Questionnaire"), e -> e.getFileName().toString().startsWith("Questionnaire-"), resourceDir);
 
         // Copy StructureDefinition resources
         var sd = meta.resolve("StructureDefinition");

--- a/src/test/resources/ExampleFishProject/fsh/package.json.template
+++ b/src/test/resources/ExampleFishProject/fsh/package.json.template
@@ -1,0 +1,23 @@
+{
+ "name": "rki.surveillance.are",
+ "version" : "0.1.0",
+ "canonical" : "https://are.surveillance.rki.de/fhir",
+ "url" : "https://simplifier.net/rki.surveillance.are",
+ "homepage" : "https://influenza.rki.de/",
+ "title" : "Implementierungsleitfaden ARE Surveillance",
+ "description": "Beinhaltet die FHIR Profile für die ARE Surveillance.",
+ "fhirVersions" : [ "4.0.1" ],
+ "dependencies" : {
+    "hl7.fhir.r4.core" : "4.0.1",
+    "hl7.terminology.r4" : "5.0.0",
+    "hl7.fhir.uv.extensions.r4" : "1.0.0",
+    "de.basisprofil.r4" : "1.3.2"
+ },
+ "author": "Robert Koch-Institut",
+ "maintainers": [
+    {
+      "name" : "Nationales Referenzzentrum für Influenza (Robert Koch-Institut)",
+      "email" : "NRZ-Influenza@rki.de",
+    }
+ ]
+}


### PR DESCRIPTION
Description:
- Example resources have been copied to the false directory: Added a hyphen to the FHIR resource type to check, which kind of type a file is. Without this, the program cannot differ between examples of "QuestionnaireResponse" and "Questionnaire".
- Copy package.json.template. This is the template file defined by DEMIS (there is also one that is defined for the IG Publisher - maybe they can be identical, maybe not! We need to check this later). This file is necessary for the Simplifier flow of the profile-loader